### PR TITLE
Feat/exception

### DIFF
--- a/src/main/java/rider/nbc/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/rider/nbc/global/exception/handler/GlobalExceptionHandler.java
@@ -14,13 +14,14 @@ import rider.nbc.global.exception.BaseException;
 import rider.nbc.global.exception.dto.ValidationError;
 import rider.nbc.global.response.CommonResponse;
 import rider.nbc.global.response.CommonResponses;
+import rider.nbc.global.util.LogUtils;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 	@ExceptionHandler(BaseException.class)
 	public ResponseEntity<CommonResponse<?>> handleBaseException(BaseException baseException) {
-		// LogUtils.logError(baseException);
+		 LogUtils.logError(baseException);
 
 		return ResponseEntity.status(baseException.getHttpStatus())
 			.body(CommonResponse.of(false, baseException.getHttpStatus().value(), baseException.getMessage()));
@@ -28,7 +29,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<CommonResponses<ValidationError>> inputValidationExceptionHandler(BindingResult result) {
-		// log.error(result.getFieldErrors().toString());
+		 log.error(result.getFieldErrors().toString());
 
 		List<ValidationError> validationErrors = result.getFieldErrors().stream()
 			.map(fieldError -> ValidationError.builder()

--- a/src/main/java/rider/nbc/global/response/CommonResponse.java
+++ b/src/main/java/rider/nbc/global/response/CommonResponse.java
@@ -1,7 +1,6 @@
 package rider.nbc.global.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,17 +8,26 @@ import lombok.Getter;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CommonResponse<T> {
-	private boolean success;
-	private int status;
-	private String message;
-	private T result;
+    private boolean success;
+    private int status;
+    private String message;
+    private T result;
 
-	public static <T> CommonResponse<T> of(boolean success, int status, String message) {
-		return CommonResponse.<T>builder()
-			.success(success)
-			.status(status)
-			.message(message)
-			.build();
-	}
+    public static <T> CommonResponse<T> of(boolean success, int status, String message, T result) {
+        return CommonResponse.<T>builder()
+                .success(success)
+                .status(status)
+                .message(message)
+                .result(result)
+                .build();
+    }
+
+    public static <T> CommonResponse<T> of(boolean success, int status, String message) {
+        return CommonResponse.<T>builder()
+                .success(success)
+                .status(status)
+                .message(message)
+                .build();
+    }
 
 }

--- a/src/main/java/rider/nbc/global/util/LogUtils.java
+++ b/src/main/java/rider/nbc/global/util/LogUtils.java
@@ -1,0 +1,18 @@
+package rider.nbc.global.util;
+
+import lombok.extern.slf4j.Slf4j;
+import rider.nbc.global.exception.BaseException;
+
+@Slf4j
+public class LogUtils {
+    public static void logError(Throwable throwable) {
+        if (throwable instanceof BaseException baseException) {
+            log.error("예외 발생: {} (ErrorCode: {})", baseException.getMessage(), baseException.getMessage());
+        }
+
+        StackTraceElement firstStackTrace = throwable.getStackTrace()[0];
+        log.error("발생 위치: {}:{} - Thread: {}, Method: {}",
+                firstStackTrace.getClassName(), firstStackTrace.getLineNumber(),
+                Thread.currentThread().getName(), firstStackTrace.getMethodName());
+    }
+}


### PR DESCRIPTION
오류가 발생했을 때 global exception handler 때문에 stack trace를 확인하기 어려우므로 어디에서 오류가 발생했는지 확인하기 위해 에러 에 대한 정보를 log로 출력